### PR TITLE
Feature erase

### DIFF
--- a/TestShell/TestShell.cpp
+++ b/TestShell/TestShell.cpp
@@ -146,11 +146,15 @@ void TestShell::erase(unsigned int address, int size) {
         }
         address = calcAddress;
     }
-    
+
+    runEraseCommand(address, size);
+}
+
+void TestShell::runEraseCommand(unsigned int address, int size)
+{
     //check over address
     if ((address + size) > ADDRESS_RANGE_MAX)
         size = (ADDRESS_RANGE_MAX - address + 1);
-    
     //check over size
     while (size > MAX_ERASE_SIZE) {
         driver->erase(address, MAX_ERASE_SIZE);
@@ -161,11 +165,12 @@ void TestShell::erase(unsigned int address, int size) {
         driver->erase(address, size);
 }
 
-void TestShell::erase_range(unsigned int start_address, unsigned int end_size) {
-    if (start_address > end_size)
-        std::swap(start_address, end_size);
-    int size = (end_size - start_address) + 1;
-    driver->erase(start_address, size);
+void TestShell::erase_range(unsigned int start_address, unsigned int end_address) {
+    if (start_address > end_address)
+        std::swap(start_address, end_address);
+    int size = (end_address - start_address) + 1;
+
+    runEraseCommand(start_address, size);
 }
 
 void TestShell::flush() {

--- a/TestShell/TestShell.h
+++ b/TestShell/TestShell.h
@@ -23,7 +23,8 @@ public:
 	bool readCompare(unsigned int address, unsigned int value);
 
 	void erase(unsigned int adress, int size);
-	void erase_range(unsigned int start_adress, unsigned int end_size);
+	void runEraseCommand(unsigned int address, int size);
+	void erase_range(unsigned int start_address, unsigned int end_address);
 
 	void flush();
 

--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -104,7 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
🔍 개요,
erase range 동작 버그 fix

✅ 작업 내용,
Issue Link,
- erase range 동작시 최대 erase size인 5를 벗어나는 경우에 대한 예외처리 반영
--> 기존 erase 동작에서 검증된 로직을 메서드화 하여 erase_range,erase 동작에 모두 체크할 수 있도록 반영함

⚠️ 의존성 (참고 사항),
