### PR TITLE
🔨[Fix]: fix console output in Script1 and add shell_scripts.txt in output folder

### DIFF
--- a/TestShell/TestShell.cpp
+++ b/TestShell/TestShell.cpp
@@ -229,7 +229,6 @@ bool TestShell::readCompareFive(int loopCnt) {
         unsigned int address = loopCnt * Script1_OnceLoopCount + iter;
         unsigned int expectedValue = ScriptTest_Value + loopCnt;
         if (read(address) != expectedValue) {
-            out << "FAIL";
             return false;
         }
     }

--- a/output/shell_scripts.txt
+++ b/output/shell_scripts.txt
@@ -1,0 +1,4 @@
+1_FullWriteAndReadCompare
+2_PartialLBAWrite
+3_WriteReadAging
+4_EraseAndWriteAging


### PR DESCRIPTION
🔍 개요,
exe 파일 실행 시에 발견된 버그 수정 및 실행 시 필요한 파일 추가(shell_scripts)

✅ 작업 내용
1. script1 파일 실행 시에 FAIL FAIL 2번 출력되어 1번 출력되도록 변경
2. Runner 실행 시에 필요한 shell_scripts.txt 추가
 
⚠️ 의존성 (참고 사항),
<!-- 리뷰어가 유의해야 할 점 -->
