### PR TITLE
[FIX] fix fullread console output format

### DIFF
--- a/TestShell/TestShell.cpp
+++ b/TestShell/TestShell.cpp
@@ -57,8 +57,8 @@ std::vector<unsigned int> TestShell::fullread() {
     out << "[Full Read: LBA 0 ~ 99]" << std::endl;
 
     for (unsigned int lba = 0; lba < 100; ++lba) {
+        out << " [LBA " << std::dec << lba << "] ";
         unsigned int data = driver->read(lba);
-        out << "[Read]" << " LBA " << lba << " : " << "0x" << std::setw(8) << std::setfill('0') << std::hex << data << std::endl;
         readDataList.push_back(data);
     }
     Logger::LogPrint("TestShell", __func__, "fullread end");


### PR DESCRIPTION
🔍 개요,
fullread 시에 read 함수 내 출력 값이랑 반복해서 출력되는 문제 수정

✅ 작업 내용,
fullread 시에 read 함수 내 출력 값이랑 반복해서 출력되는 문제 수정 했습니다!

⚠️ 의존성 (참고 사항),
<!-- 리뷰어가 유의해야 할 점 -->
